### PR TITLE
BUGFIX: swipe fadeIn 효과가 정상 동작하지 않는 이슈

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -423,7 +423,7 @@
       mdownpos.y = mpos.y = pageY;
       mtimestamp = e.timeStamp;
     }).on('touchend touchleave', function (e) {
-      if (mdown) $el.trigger('dragend');
+      if (mdown && mdirection !== 'y') $el.trigger('dragend');
       mdown = false;
     }).on('touchmove', function (e) {
       // ignore vertical oriented mousemove

--- a/swipe.js
+++ b/swipe.js
@@ -54,10 +54,8 @@
     }
   };
 
-  var _drag_ended = true,
-      _drag_blocked = false;
-  var animateFadeIn = function($target_wrap, pos, options) {
-    if (_drag_ended && !_drag_blocked){
+  var animateFadeIn = function($target_wrap, pos, options, drag_ended, drag_blocked) {
+    if (drag_ended && !drag_blocked){
       $target_wrap.animate({'opacity': 0}, options.transition_ms,
         function() {
           $(this).css({
@@ -116,6 +114,8 @@
     this.total = options.total;
     this.curr_px = 0;
     this.options = options;
+    this._drag_ended = true;
+    this._drag_blocked = false;
     this.init();
   };
   Swipe.prototype = {
@@ -162,7 +162,7 @@
 
       var this_ = this;
       this._as_next = function () {
-        _drag_blocked = false;
+        this_._drag_blocked = false;
         if (this_._as_timeout_id || (this_.p === this_.total && !this_.options.infinite)) {
           clearTimeout(this_._as_timeout_id);
           return;
@@ -189,24 +189,24 @@
     onPrev: function (e) {
       e.preventDefault();
       e.stopPropagation();
-      _drag_blocked = false;
+      this._drag_blocked = false;
       if (this.p === 1 && !this.options.infinite) return;
       this.swipePrev();
     },
     onNext: function (e) {
       e.preventDefault();
       e.stopPropagation();
-      _drag_blocked = false;
+      this._drag_blocked = false;
       if (this.p === this.total && !this.options.infinite) return;
       this.swipeNext();
     },
     onDragLeft: function (e, velocityX, deltaX) {
       if (this._swiped) return;
       if (this.p === this.total && !this.options.infinite) {
-        _drag_blocked = true;
+        this._drag_blocked = true;
         return;
       }
-      _drag_blocked = false;
+      this._drag_blocked = false;
       window.addEventListener('touchmove', function(e) {
         e.preventDefault();
         e.stopPropagation();
@@ -215,7 +215,7 @@
           !(this.p === this.total && !this.options.infinite)) {
         e.preventDefault();
         e.stopPropagation();
-        _drag_ended = true;
+        this._drag_ended = true;
         this._swiped = true;
         this.curr_px = 0;
         this._setTransitionDuration(0);
@@ -228,10 +228,10 @@
     onDragRight: function (e, velocityX, deltaX) {
       if (this._swiped) return;
       if (this.p === 1 && !this.options.infinite) {
-        _drag_blocked = true;
+        this._drag_blocked = true;
         return;
       }
-      _drag_blocked = false;
+      this._drag_blocked = false;
       window.addEventListener('touchmove', function(e) {
         e.preventDefault();
         e.stopPropagation();
@@ -240,7 +240,7 @@
           !(this.p === 1 && !this.options.infinite)) {
         e.preventDefault();
         e.stopPropagation();
-        _drag_ended = true;
+        this._drag_ended = true;
         this._swiped = true;
         this.curr_px = 0;
         this._setTransitionDuration(0);
@@ -251,11 +251,11 @@
       this.animate_px(l);
     },
     onDragStart: function (e) {
-      _drag_ended = false;
+      this._drag_ended = false;
       this._setTransitionDuration(0);
     },
     onDragEnd: function (e) {
-      _drag_ended = true;
+      this._drag_ended = true;
       this._setTransitionDuration(this.options.transition_ms);
       if (!this._swiped) this.animate();
       this._swiped = false;
@@ -278,7 +278,7 @@
       });
     },
     onSwipePage: function (e, new_page) {
-      _drag_blocked = false;
+      this._drag_blocked = false;
       if (new_page < 1 || new_page > this.total) return;
       this.p = new_page;
       this.animate();
@@ -381,7 +381,7 @@
       var t = -((this.p - 1 + this.offset * this.total) *
           this.getWidth(true)) / this.total;
 
-      animateFactory(this.options.animation_type)(this.$target_wrap, t, this.options);
+      animateFactory(this.options.animation_type)(this.$target_wrap, t, this.options, this._drag_ended, this._drag_blocked);
       if (!this.options.infinite) {
         if (this.options.$prev)
           this.options.$prev.toggleClass('disabled', this.p === 1);
@@ -399,7 +399,7 @@
       this.curr_px = px;
       var t = -((this.p - 1 + this.offset * this.total) *
           this.getWidth()) / this.total + px;
-      animateFactory(this.options.animation_type)(this.$target_wrap, t, this.options);
+      animateFactory(this.options.animation_type)(this.$target_wrap, t, this.options, this._drag_ended, this._drag_blocked);
     },
 
     // ## methods for user

--- a/swipe.js
+++ b/swipe.js
@@ -54,19 +54,18 @@
     }
   };
 
-  // dragEnd 감지 위한 변수 추가
-  var _is_dragged = false;
+  var _drag_ended = true;
   var animateFadeIn = function($target_wrap, pos, options) {
-    $target_wrap.animate({'opacity': 0}, options.transition_ms,
-      function() {
-        if (!_is_dragged){
+    if (_drag_ended){
+      $target_wrap.animate({'opacity': 0}, options.transition_ms,
+        function() {
           $(this).css({
             'margin-left': pos + 'px'
           });
           $(this).animate({'opacity': 1}, options.transition_ms + 200);
         }
-      }
-    );
+      );
+    }
   };
 
   var animateNone = function($target_wrap, pos, options) {
@@ -199,6 +198,7 @@
     },
     onDragLeft: function (e, velocityX, deltaX) {
       if (this._swiped) return;
+      if (this.p === this.total && !this.options.infinite) return;
       window.addEventListener('touchmove', function(e) {
         e.preventDefault();
         e.stopPropagation();
@@ -207,6 +207,7 @@
           !(this.p === this.total && !this.options.infinite)) {
         e.preventDefault();
         e.stopPropagation();
+        _drag_ended = true;
         this._swiped = true;
         this.curr_px = 0;
         this._setTransitionDuration(0);
@@ -218,14 +219,16 @@
     },
     onDragRight: function (e, velocityX, deltaX) {
       if (this._swiped) return;
+      if (this.p === 1 && !this.options.infinite) return;
       window.addEventListener('touchmove', function(e) {
         e.preventDefault();
         e.stopPropagation();
       }, { passive:false });
       if (Math.abs(velocityX) > 5 &&
-          !(this.p === this.total && !this.options.infinite)) {
+          !(this.p === 1 && !this.options.infinite)) {
         e.preventDefault();
         e.stopPropagation();
+        _drag_ended = true;
         this._swiped = true;
         this.curr_px = 0;
         this._setTransitionDuration(0);
@@ -236,11 +239,11 @@
       this.animate_px(l);
     },
     onDragStart: function (e) {
-      _is_dragged = true;
+      _drag_ended = false;
       this._setTransitionDuration(0);
     },
     onDragEnd: function (e) {
-      _is_dragged = false;
+      _drag_ended = true;
       this._setTransitionDuration(this.options.transition_ms);
       if (!this._swiped) this.animate();
       this._swiped = false;
@@ -475,5 +478,3 @@
     });
   };
 }));
-
-// TODO: 중복된 코드 리팩토링 필요

--- a/swipe.js
+++ b/swipe.js
@@ -162,8 +162,9 @@
 
       var this_ = this;
       this._as_next = function () {
-        if (this_._as_timeout_id) {
+        if (this_._as_timeout_id || (this_.p === this_.total && !this_.options.infinite)) {
           clearTimeout(this_._as_timeout_id);
+          return;
         }
         this_._as_timeout_id = setTimeout(function () {
           if (!this_._as_pause) this_.swipeNext();

--- a/swipe.js
+++ b/swipe.js
@@ -115,7 +115,6 @@
     this.offset = 0;
     this.total = options.total;
     this.curr_px = 0;
-    this.disabled_touch = false;
     this.options = options;
     this.init();
   };
@@ -199,7 +198,10 @@
     },
     onDragLeft: function (e, velocityX, deltaX) {
       if (this._swiped) return;
-      $(window).on('touchmove', this.disabled_touch);
+      window.addEventListener('touchmove', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+      }, { passive:false });
       if (Math.abs(velocityX) > 5 &&
           !(this.p === this.total && !this.options.infinite)) {
         e.preventDefault();
@@ -215,7 +217,10 @@
     },
     onDragRight: function (e, velocityX, deltaX) {
       if (this._swiped) return;
-      $(window).on('touchmove', this.disabled_touch);
+      window.addEventListener('touchmove', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+      }, { passive:false });
       if (Math.abs(velocityX) > 5 &&
           !(this.p === this.total && !this.options.infinite)) {
         e.preventDefault();
@@ -238,7 +243,10 @@
       this._setTransitionDuration(this.options.transition_ms);
       if (!this._swiped) this.animate();
       this._swiped = false;
-      $(window).off('touchmove', this.disabled_touch);
+      window.removeEventListener('touchmove', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+      }, { passive:false });
     },
     onSwipeTotal: function (e, new_total) {
       var this_ = this;
@@ -466,3 +474,5 @@
     });
   };
 }));
+
+// TODO: 중복된 코드 리팩토링 필요

--- a/swipe.js
+++ b/swipe.js
@@ -54,9 +54,10 @@
     }
   };
 
-  var _drag_ended = true;
+  var _drag_ended = true,
+      _drag_blocked = false;
   var animateFadeIn = function($target_wrap, pos, options) {
-    if (_drag_ended){
+    if (_drag_ended && !_drag_blocked){
       $target_wrap.animate({'opacity': 0}, options.transition_ms,
         function() {
           $(this).css({
@@ -161,6 +162,7 @@
 
       var this_ = this;
       this._as_next = function () {
+        _drag_blocked = false;
         if (this_._as_timeout_id || (this_.p === this_.total && !this_.options.infinite)) {
           clearTimeout(this_._as_timeout_id);
           return;
@@ -187,18 +189,24 @@
     onPrev: function (e) {
       e.preventDefault();
       e.stopPropagation();
+      _drag_blocked = false;
       if (this.p === 1 && !this.options.infinite) return;
       this.swipePrev();
     },
     onNext: function (e) {
       e.preventDefault();
       e.stopPropagation();
+      _drag_blocked = false;
       if (this.p === this.total && !this.options.infinite) return;
       this.swipeNext();
     },
     onDragLeft: function (e, velocityX, deltaX) {
       if (this._swiped) return;
-      if (this.p === this.total && !this.options.infinite) return;
+      if (this.p === this.total && !this.options.infinite) {
+        _drag_blocked = true;
+        return;
+      }
+      _drag_blocked = false;
       window.addEventListener('touchmove', function(e) {
         e.preventDefault();
         e.stopPropagation();
@@ -219,7 +227,11 @@
     },
     onDragRight: function (e, velocityX, deltaX) {
       if (this._swiped) return;
-      if (this.p === 1 && !this.options.infinite) return;
+      if (this.p === 1 && !this.options.infinite) {
+        _drag_blocked = true;
+        return;
+      }
+      _drag_blocked = false;
       window.addEventListener('touchmove', function(e) {
         e.preventDefault();
         e.stopPropagation();
@@ -266,6 +278,7 @@
       });
     },
     onSwipePage: function (e, new_page) {
+      _drag_blocked = false;
       if (new_page < 1 || new_page > this.total) return;
       this.p = new_page;
       this.animate();

--- a/swipe.js
+++ b/swipe.js
@@ -7,6 +7,7 @@
  * (c) 2015 goonoo (mctenshi@gmail.com)
  * Released under the MIT license
  */
+
 (function (factory) {
   "use strict";
 
@@ -53,13 +54,17 @@
     }
   };
 
+  // dragEnd 감지 위한 변수 추가
+  var _is_dragged = false;
   var animateFadeIn = function($target_wrap, pos, options) {
     $target_wrap.animate({'opacity': 0}, options.transition_ms,
       function() {
-        $(this).css({
-          'margin-left': pos + 'px'
-        });
-        $(this).animate({'opacity': 1});
+        if (!_is_dragged){
+          $(this).css({
+            'margin-left': pos + 'px'
+          });
+          $(this).animate({'opacity': 1}, options.transition_ms + 200);
+        }
       }
     );
   };
@@ -225,9 +230,11 @@
       this.animate_px(l);
     },
     onDragStart: function (e) {
+      _is_dragged = true;
       this._setTransitionDuration(0);
     },
     onDragEnd: function (e) {
+      _is_dragged = false;
       this._setTransitionDuration(this.options.transition_ms);
       if (!this._swiped) this.animate();
       this._swiped = false;


### PR DESCRIPTION
# Do

- `animate default(400) 값이 적용되어 의도와 다르게 동작` ->  fadeIn duration time 추가 , dragEnd 시점에 콜백함수 실행되도록 조건 추가
- `상하 드래그에서도 fadeIn이 동작해 깜빡임` -> dragEnd trigger에 Y축이 아닌 경우에 대한 조건 추가
- `(!연속페이징 && 자동페이징 && 마지막 페이지) 일 때, next 함수가 계속 동작해 깜빡임` -> 조건 추가
- `(!연속페이징) 일 때, 첫페이지 dragLeft나 마지막페이지 dragRight가 동작해 깜빡임` -> drag block하기 위한 변수, 조건 추가
- `크롬 브라우저 passive 에러 대응` -> javascript 대응 코드 추가

# Sample

- [버그 재현 예제](https://minjiicho.github.io/test/infinite-swipe/)
- 모바일뷰에서 스와이프 동작으로 재현 가능합니다
- infinite & autoswipe 옵션은 false 처리된 예제입니다

# Why

- 모바일에서 fadeIn 효과가 정상적으로 동작하지 않는 이슈
